### PR TITLE
Centralize animation

### DIFF
--- a/os1/os_1.script
+++ b/os1/os_1.script
@@ -38,7 +38,6 @@ loading_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - loading_image[0].Ge
 loading_sprite.SetY(Window.GetY() + (Window.GetHeight() / 2 - loading_image[0].GetHeight() / 2));
 
 // set background size
-loading_sprite = Sprite();
 background_image = Image("background.png");
 background_sprite = Sprite();
 background_sprite.SetX(Window.GetX() + (Window.GetWidth() / 2 - background_image.GetWidth() / 2));


### PR DESCRIPTION
Because of one line, the animation was showing at the upper left corner of the screen instead of the center.

This PR fixes that.